### PR TITLE
Create common gitignore for modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,20 +1,34 @@
-# Local .terraform directories
+# Common .gitignore for HVD Modules
+# If you need to add a rule, add it to the hvd-module-template repo
+
+# Ignore product license files
+*.hclic
+*.rli
+
+# Ignore local .terraform directories
 **/.terraform/*
 
-# .tfstate files
+# Ignore common plan output filenames
+*tfplan*
+*.tfplan
+
+# Ignore generated .tfstate files
 *.tfstate
 *.tfstate.*
 
-# Crash log files
-crash.log
-crash.*.log
-
-# Exclude all .tfvars files, which are likely to contain sensitive data, such as
+# Ignore all .tfvars files, which are likely to contain sensitive data, such as
 # password, private keys, and other secrets. These should not be part of version 
 # control as they are data points which are potentially sensitive and subject 
 # to change depending on the environment.
 *.tfvars
 *.tfvars.json
+
+# Ignore Terraform dependency lock files
+.terraform.lock.hcl
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc
 
 # Ignore override files as they are usually used to override resources locally and so
 # are not checked in
@@ -23,12 +37,15 @@ override.tf.json
 *_override.tf
 *_override.tf.json
 
-# Include override files you do wish to add to version control using negated pattern
-# !example_override.tf
+# Ignore crash log files
+crash.*.log
+crash.log
 
-# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
-# example: *tfplan*
+# Ignore macOS DS_Store files
+.DS_Store
 
-# Ignore CLI configuration files
-.terraformrc
-terraform.rc
+# Ignore local dev/test Kubernetes/Helm config files
+local_*.yaml
+
+# Ignore module-generated Helm overrides file
+module_generated_helm_overrides.yaml# Local .terraform directories


### PR DESCRIPTION
## Description
Merged gitignore configuration from all HVD Modules to a common file we can manage in this template. This will ensure the repos are managed in a consistent way, eg ignoring terraform provider lock files across all repos.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How has this been tested?
- Concatenated all gitignores from HVD Modules to a single file (scripted)
- Sorted results and removed duplicates (scripted)
- Re-organised file to ensure comments next to ignore patterns were all relevant and accurate (manual)

```
# from within a local "~/code/hashicorp" directory where all hashicorp org repos are cloned
find . -type f -name ".gitignore" -path "*hvd/*" -exec sh -c 'cat "{}"; echo' \; > combined_gitignore && \
sort -u combined_gitignore -o unique_gitignore
``` 

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Additional notes
Plan going forward is gitignore changes will be made to this file and then pushed to HVD modules to maintain consistency
