### PR TITLE
add jira and template sync

### DIFF
--- a/.github/workflows/jira-sync.yml
+++ b/.github/workflows/jira-sync.yml
@@ -1,0 +1,16 @@
+name: Jira Sync
+on:
+  issues:
+    types: [opened, closed, deleted, reopened]
+  pull_request_target:
+    types: [opened, closed, reopened]
+  issue_comment: # Also triggers when commenting on a PR from the conversation view
+    types: [created]
+jobs:
+  sync:
+    uses: hashicorp/hvd-module-gha/.github/workflows/jira-sync.yml@main
+
+    secrets:
+      JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
+      JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
+      JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}

--- a/.github/workflows/template-sync.yml
+++ b/.github/workflows/template-sync.yml
@@ -1,0 +1,8 @@
+name: Jira Sync
+on:
+  schedule:
+    - cron: "0 0 1 * *"
+  workflow_dispatch:
+jobs:
+  sync:
+    uses: hashicorp/hvd-module-gha/.github/workflows/template-sync.yml@main


### PR DESCRIPTION
## Description

Adds Jira sync and template sync workflows to the templates. Once the template sync has been deployed in all targets hvd modules, we can use template updates to roll updates downstream to hvd modules. 

## Type of change

- [X] New feature (non-breaking change which adds functionality)

