### PR TITLE
Update release process and support scripts

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -90,29 +90,77 @@ The release process will do the following.
 1. Create a tagged release
 1. Generate release notes
 1. Create a GitHub release
-1. Clean up the temporary release branch
+1. Update CHANGELOG
+1. Create PR
 
 ```
-MOD_RELEASE=0.1.2 task release -n
-task: [release] export MOD_REPO="terraform-<provider>-<product>-hvd"
-export MOD_RELEASE="0.1.2"
+ MOD_RELEASE=1.2.3 task release -vn
+task: dynamic variable: "echo \"${PWD##*/}\"" result: "hvd-module-template"
+task: dynamic variable: "git config --local remote.origin.url | cut -d':' -f2 | cut -d'/' -f1" result: "hashicorp"
+fatal: No names found, cannot describe anything.
+task: dynamic variable: "git describe --tags $(git rev-list --tags --max-count=1) || echo \"\"" result: ""
+task: "release" started
+task: [release] export MOD_REPO="hvd-module-template"
+export MOD_RELEASE="1.2.3"
 export REPO_OWNER="hashicorp"
-echo "Releasing hashicorp/terraform-<provider>-<product>-hvd version 0.1.2"
+echo "Releasing hashicorp/hvd-module-template version 1.2.3"
 
-task: [release] git checkout -b rel-${MOD_RELEASE}
-task: [release] python .github/scripts/markdown-url-converter/markdown-url-converter.py --repo="hashicorp/terraform-<provider>-<product>-hvd" --release="0.1.2" --overwrite .
+task: [release] git checkout -b release/rc-${MOD_RELEASE}
+task: [release] python .github/scripts/markdown-url-converter/markdown-url-converter.py --repo="hashicorp/hvd-module-template" --release="1.2.3" --overwrite .
 
 task: [release] git commit  --allow-empty -am "Release version ${MOD_RELEASE}"
 task: [release] git tag -a ${MOD_RELEASE} -m "${MOD_RELEASE} release"
-task: [release] git revert HEAD --no-edit
 task: [release] git push origin --tags
-task: [release] git push origin rel-${MOD_RELEASE}
-task: [release] gh release create 0.1.2 \
---repo hashicorp/terraform-<provider>-<product>-hvd \
---title "0.1.2" \
---generate-notes --verify-tag
+task: [release] git revert HEAD --no-edit -n
+task: [release] git commit -m "Revert release commit to retain tag in history"
+task: [release] git push origin release/rc-${MOD_RELEASE}
+task: [release] RELEASE_NOTES=$(gh release view 1.2.3 --repo hashicorp/hvd-module-template --json body --jq .body)
+TEMP_FILE=$(mktemp)
+echo "## v1.2.3" > $TEMP_FILE
+echo "" >> $TEMP_FILE
+trap 'rm -f "$TEMP_FILE"' EXIT
+echo "## v1.2.3" > "$TEMP_FILE"
+echo "" >> "$TEMP_FILE"
+echo "$RELEASE_NOTES" >> "$TEMP_FILE"
+echo "" >> "$TEMP_FILE"
+tail -n +1 CHANGELOG.md >> "$TEMP_FILE"
+mv "$TEMP_FILE" CHANGELOG.md
+trap - EXIT
+git add CHANGELOG.md
+git commit -m "chore: update CHANGELOG.md for v1.2.3"
+git push origin release/rc-${MOD_RELEASE}
 
-task: [release] git push origin --delete rel-${MOD_RELEASE}
+task: [release] git tag -af ${MOD_RELEASE} -m "${MOD_RELEASE} release"
+task: [release] git push origin --tags -f
+task: [release] # Wait for the updated tag to be visible on the remote before creating the release
+for i in {1..10}; do
+  if git ls-remote --tags origin | grep -q "refs/tags/${MOD_RELEASE}$"; then
+    echo "Tag ${MOD_RELEASE} is now available on origin."
+    break
+  fi
+  echo "Waiting for tag ${MOD_RELEASE} to propagate to origin (attempt ${i}/10)..."
+  sleep 3
+done
+gh release create 1.2.3 \
+--repo hashicorp/hvd-module-template \
+--title "1.2.3" \
+--generate-notes --notes-start-tag
+
+task: [release] RELEASE_NOTES=$(gh release view 1.2.3 --repo hashicorp/hvd-module-template --json body --jq .body)
+PR_BODY_FILE=$(mktemp)
+echo "Release version 1.2.3" > "$PR_BODY_FILE"
+echo "" >> "$PR_BODY_FILE"
+echo "$RELEASE_NOTES" >> "$PR_BODY_FILE"
+gh pr create \
+--repo hashicorp/hvd-module-template \
+--title "Release 1.2.3" \
+--body-file "$PR_BODY_FILE" \
+--base main \
+--head release/rc-${MOD_RELEASE} || true
+
+task: [release] git checkout main
+task: "release" finished
+
 ```
 
 > You can also set the `MOD_RELEASE` variable in a `.env.local` file for convenience.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -97,8 +97,7 @@ The release process will do the following.
  MOD_RELEASE=1.2.3 task release -vn
 task: dynamic variable: "echo \"${PWD##*/}\"" result: "hvd-module-template"
 task: dynamic variable: "git config --local remote.origin.url | cut -d':' -f2 | cut -d'/' -f1" result: "hashicorp"
-fatal: No names found, cannot describe anything.
-task: dynamic variable: "git describe --tags $(git rev-list --tags --max-count=1) || echo \"\"" result: ""
+task: dynamic variable: "git describe --tags $(git rev-list --tags --max-count=1) 2>/dev/null || echo \"\"" result: ""
 task: "release" started
 task: [release] export MOD_REPO="hvd-module-template"
 export MOD_RELEASE="1.2.3"
@@ -116,8 +115,7 @@ task: [release] git commit -m "Revert release commit to retain tag in history"
 task: [release] git push origin release/rc-${MOD_RELEASE}
 task: [release] RELEASE_NOTES=$(gh release view 1.2.3 --repo hashicorp/hvd-module-template --json body --jq .body)
 TEMP_FILE=$(mktemp)
-echo "## v1.2.3" > $TEMP_FILE
-echo "" >> $TEMP_FILE
+
 echo "## v1.2.3" > "$TEMP_FILE"
 echo "" >> "$TEMP_FILE"
 echo "$RELEASE_NOTES" >> "$TEMP_FILE"

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -118,14 +118,12 @@ task: [release] RELEASE_NOTES=$(gh release view 1.2.3 --repo hashicorp/hvd-modul
 TEMP_FILE=$(mktemp)
 echo "## v1.2.3" > $TEMP_FILE
 echo "" >> $TEMP_FILE
-trap 'rm -f "$TEMP_FILE"' EXIT
 echo "## v1.2.3" > "$TEMP_FILE"
 echo "" >> "$TEMP_FILE"
 echo "$RELEASE_NOTES" >> "$TEMP_FILE"
 echo "" >> "$TEMP_FILE"
 tail -n +1 CHANGELOG.md >> "$TEMP_FILE"
 mv "$TEMP_FILE" CHANGELOG.md
-trap - EXIT
 git add CHANGELOG.md
 git commit -m "chore: update CHANGELOG.md for v1.2.3"
 git push origin release/rc-${MOD_RELEASE}

--- a/.github/scripts/markdown-url-converter/markdown-url-converter.py
+++ b/.github/scripts/markdown-url-converter/markdown-url-converter.py
@@ -112,10 +112,13 @@ def convert_markdown_urls(content: str, base_url: str, file_path: Path, root_dir
     return result
 
 def find_markdown_files(directory: Path) -> List[Path]:
-    """Find all markdown files in the directory tree."""
+    """Find all markdown files in the directory tree, ignoring hidden folders."""
     markdown_files = []
     for ext in ['.md', '.markdown']:
-        markdown_files.extend(directory.rglob(f'*{ext}'))
+        for file_path in directory.rglob(f'*{ext}'):
+            # Skip files in hidden directories (folders starting with '.')
+            if not any(part.startswith('.') for part in file_path.relative_to(directory).parts):
+                markdown_files.append(file_path)
     return sorted(markdown_files)
 
 def process_file(file_path: Path, base_url: str, root_dir: Path, dry_run: bool = False, overwrite: bool = False) -> Tuple[bool, str]:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -133,7 +133,6 @@ tasks:
           tail -n +1 CHANGELOG.md >> "$TEMP_FILE"
         fi
         mv "$TEMP_FILE" CHANGELOG.md
-        trap - EXIT
         git add CHANGELOG.md
         git commit -m "chore: update CHANGELOG.md for v{{.MOD_RELEASE}}"
         git push origin release/rc-${MOD_RELEASE}

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -131,7 +131,9 @@ tasks:
         echo "" >> "$TEMP_FILE"
         echo "$RELEASE_NOTES" >> "$TEMP_FILE"
         echo "" >> "$TEMP_FILE"
-        tail -n +1 CHANGELOG.md >> "$TEMP_FILE"
+        if [ -f CHANGELOG.md ]; then
+          tail -n +1 CHANGELOG.md >> "$TEMP_FILE"
+        fi
         mv "$TEMP_FILE" CHANGELOG.md
         trap - EXIT
         git add CHANGELOG.md

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -103,7 +103,7 @@ tasks:
       REPO_OWNER:
         sh: git config --local remote.origin.url | cut -d':' -f2 | cut -d'/' -f1
       PREV_TAG:
-        sh: git describe --tags $(git rev-list --tags --max-count=1) || echo "" # Get the latest tag or return empty string if no tags exist
+        sh: git describe --tags $(git rev-list --tags --max-count=1) 2>/dev/null || printf '' # Get the latest tag or return empty string if no tags exist
     env:
       MOD_RELEASE: '{{.MOD_RELEASE}}'
     cmds:
@@ -137,7 +137,7 @@ tasks:
         git commit -m "chore: update CHANGELOG.md for v{{.MOD_RELEASE}}"
         git push origin release/rc-${MOD_RELEASE}
       - git tag -af ${MOD_RELEASE} -m "${MOD_RELEASE} release"
-      - git push origin --tags -f
+      - git push origin refs/tags/${MOD_RELEASE} -f
       - |
         # Wait for the updated tag to be visible on the remote before creating the release
         for i in {1..10}; do
@@ -149,23 +149,43 @@ tasks:
           sleep 3
         done
 
-        GH_RELEASE_ARGS="--repo {{.REPO_OWNER}}/{{.MOD_REPO}} --title \"{{.MOD_RELEASE}}\" --generate-notes"
         if [ -n "{{.PREV_TAG}}" ]; then
-          GH_RELEASE_ARGS="$GH_RELEASE_ARGS --notes-start-tag {{.PREV_TAG}}"
+          gh release create "{{.MOD_RELEASE}}" \
+            --repo "{{.REPO_OWNER}}/{{.MOD_REPO}}" \
+            --title "{{.MOD_RELEASE}}" \
+            --generate-notes \
+            --notes-start-tag "{{.PREV_TAG}}"
+        else
+          gh release create "{{.MOD_RELEASE}}" \
+            --repo "{{.REPO_OWNER}}/{{.MOD_REPO}}" \
+            --title "{{.MOD_RELEASE}}" \
+            --generate-notes
         fi
-        gh release create {{.MOD_RELEASE}} $GH_RELEASE_ARGS
       - |
         RELEASE_NOTES=$(gh release view {{.MOD_RELEASE}} --repo {{.REPO_OWNER}}/{{.MOD_REPO}} --json body --jq .body)
         PR_BODY_FILE=$(mktemp)
         echo "Release version {{.MOD_RELEASE}}" > "$PR_BODY_FILE"
         echo "" >> "$PR_BODY_FILE"
         echo "$RELEASE_NOTES" >> "$PR_BODY_FILE"
-        gh pr create \
+        if ! gh pr create \
           --repo {{.REPO_OWNER}}/{{.MOD_REPO}} \
           --title "Release {{.MOD_RELEASE}}" \
           --body-file "$PR_BODY_FILE" \
           --base main \
-          --head release/rc-${MOD_RELEASE} || true
+          --head release/rc-${MOD_RELEASE}; then
+          # If PR creation failed, check whether an open PR from this branch already exists.
+          if gh pr list \
+            --repo {{.REPO_OWNER}}/{{.MOD_REPO}} \
+            --head "release/rc-${MOD_RELEASE}" \
+            --state open \
+            --json number \
+            --jq '.[0].number' >/dev/null 2>&1; then
+            echo "Pull request from release/rc-${MOD_RELEASE} already exists; continuing."
+          else
+            echo "Failed to create pull request for release/rc-${MOD_RELEASE}." >&2
+            exit 1
+          fi
+        fi
 
       # Note: release/rc-${MOD_RELEASE} branches are preserved after creating the PR.
       # To clean up after the release PR has been merged, delete the branch manually:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -124,6 +124,7 @@ tasks:
       - |
         RELEASE_NOTES=$(gh release view {{.MOD_RELEASE}} --repo {{.REPO_OWNER}}/{{.MOD_REPO}} --json body --jq .body)
         TEMP_FILE=$(mktemp)
+        trap 'rm -f "$TEMP_FILE"' EXIT
         echo "## v{{.MOD_RELEASE}}" > "$TEMP_FILE"
         echo "" >> "$TEMP_FILE"
         echo "$RELEASE_NOTES" >> "$TEMP_FILE"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -128,7 +128,9 @@ tasks:
         echo "" >> $TEMP_FILE
         echo "$RELEASE_NOTES" >> $TEMP_FILE
         echo "" >> $TEMP_FILE
-        tail -n +1 CHANGELOG.md >> $TEMP_FILE
+        if [ -f CHANGELOG.md ]; then
+          tail -n +1 CHANGELOG.md >> $TEMP_FILE
+        fi
         mv $TEMP_FILE CHANGELOG.md
         git add CHANGELOG.md
         git commit -m "chore: update CHANGELOG.md for v{{.MOD_RELEASE}}"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -112,19 +112,40 @@ tasks:
         export MOD_RELEASE="{{.MOD_RELEASE}}"
         export REPO_OWNER="{{.REPO_OWNER}}"
         echo "Releasing {{.REPO_OWNER}}/{{.MOD_REPO}} version {{.MOD_RELEASE}}"
-      - git checkout -b rel-${MOD_RELEASE}
+      - git checkout -b release/rc-${MOD_RELEASE}
       - |
         python .github/scripts/markdown-url-converter/markdown-url-converter.py --repo="{{.REPO_OWNER}}/{{.MOD_REPO}}" --release="{{.MOD_RELEASE}}" --overwrite .
       - git commit  --allow-empty -am "Release version ${MOD_RELEASE}"
       - git tag -a ${MOD_RELEASE} -m "${MOD_RELEASE} release"
-      - git revert HEAD --no-edit -n
       - git push origin --tags
-      - git push origin rel-${MOD_RELEASE}
+      - git revert HEAD --no-edit -n
+      - git push origin release/rc-${MOD_RELEASE}
+      - |
+        RELEASE_NOTES=$(gh release view {{.MOD_RELEASE}} --repo {{.REPO_OWNER}}/{{.MOD_REPO}} --json body --jq .body)
+        TEMP_FILE=$(mktemp)
+        echo "## v{{.MOD_RELEASE}}" > $TEMP_FILE
+        echo "" >> $TEMP_FILE
+        echo "$RELEASE_NOTES" >> $TEMP_FILE
+        echo "" >> $TEMP_FILE
+        tail -n +1 CHANGELOG.md >> $TEMP_FILE
+        mv $TEMP_FILE CHANGELOG.md
+        git add CHANGELOG.md
+        git commit -m "chore: update CHANGELOG.md for v{{.MOD_RELEASE}}"
+        git push origin release/rc-${MOD_RELEASE}
+      - git tag -af ${MOD_RELEASE} -m "${MOD_RELEASE} release"
+      - git push origin --tags -f
       - |
         gh release create {{.MOD_RELEASE}} \
         --repo {{.REPO_OWNER}}/{{.MOD_REPO}} \
         --title "{{.MOD_RELEASE}}" \
         --generate-notes --notes-start-tag {{.PREV_TAG}} --verify-tag
-      - git push origin --delete rel-${MOD_RELEASE}
+      - |
+        gh pr create \
+        --repo {{.REPO_OWNER}}/{{.MOD_REPO}} \
+        --title "Release {{.MOD_RELEASE}}" \
+        --body "Release version {{.MOD_RELEASE}}" \
+        --base main \
+        --head release/rc-${MOD_RELEASE}
+
+      # - git push origin --delete release/rc-${MOD_RELEASE}
       - git checkout main
-      - git branch -D rel-${MOD_RELEASE}

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -119,6 +119,7 @@ tasks:
       - git tag -a ${MOD_RELEASE} -m "${MOD_RELEASE} release"
       - git push origin --tags
       - git revert HEAD --no-edit -n
+      - git commit -m "Revert release commit to retain tag in history"
       - git push origin release/rc-${MOD_RELEASE}
       - |
         RELEASE_NOTES=$(gh release view {{.MOD_RELEASE}} --repo {{.REPO_OWNER}}/{{.MOD_REPO}} --json body --jq .body)

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -124,9 +124,6 @@ tasks:
       - |
         RELEASE_NOTES=$(gh release view {{.MOD_RELEASE}} --repo {{.REPO_OWNER}}/{{.MOD_REPO}} --json body --jq .body)
         TEMP_FILE=$(mktemp)
-        echo "## v{{.MOD_RELEASE}}" > $TEMP_FILE
-        echo "" >> $TEMP_FILE
-        trap 'rm -f "$TEMP_FILE"' EXIT
         echo "## v{{.MOD_RELEASE}}" > "$TEMP_FILE"
         echo "" >> "$TEMP_FILE"
         echo "$RELEASE_NOTES" >> "$TEMP_FILE"
@@ -151,10 +148,12 @@ tasks:
           echo "Waiting for tag ${MOD_RELEASE} to propagate to origin (attempt ${i}/10)..."
           sleep 3
         done
-        gh release create {{.MOD_RELEASE}} \
-        --repo {{.REPO_OWNER}}/{{.MOD_REPO}} \
-        --title "{{.MOD_RELEASE}}" \
-        --generate-notes --notes-start-tag {{.PREV_TAG}}
+
+        GH_RELEASE_ARGS="--repo {{.REPO_OWNER}}/{{.MOD_REPO}} --title \"{{.MOD_RELEASE}}\" --generate-notes"
+        if [ -n "{{.PREV_TAG}}" ]; then
+          GH_RELEASE_ARGS="$GH_RELEASE_ARGS --notes-start-tag {{.PREV_TAG}}"
+        fi
+        gh release create {{.MOD_RELEASE}} $GH_RELEASE_ARGS
       - |
         RELEASE_NOTES=$(gh release view {{.MOD_RELEASE}} --repo {{.REPO_OWNER}}/{{.MOD_REPO}} --json body --jq .body)
         PR_BODY_FILE=$(mktemp)
@@ -162,11 +161,11 @@ tasks:
         echo "" >> "$PR_BODY_FILE"
         echo "$RELEASE_NOTES" >> "$PR_BODY_FILE"
         gh pr create \
-        --repo {{.REPO_OWNER}}/{{.MOD_REPO}} \
-        --title "Release {{.MOD_RELEASE}}" \
-        --body-file "$PR_BODY_FILE" \
-        --base main \
-        --head release/rc-${MOD_RELEASE} || true
+          --repo {{.REPO_OWNER}}/{{.MOD_REPO}} \
+          --title "Release {{.MOD_RELEASE}}" \
+          --body-file "$PR_BODY_FILE" \
+          --base main \
+          --head release/rc-${MOD_RELEASE} || true
 
       # Note: release/rc-${MOD_RELEASE} branches are preserved after creating the PR.
       # To clean up after the release PR has been merged, delete the branch manually:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -103,7 +103,7 @@ tasks:
       REPO_OWNER:
         sh: git config --local remote.origin.url | cut -d':' -f2 | cut -d'/' -f1
       PREV_TAG:
-        sh: git describe --tags $(git rev-list --tags --max-count=1)
+        sh: git describe --tags $(git rev-list --tags --max-count=1) || echo "" # Get the latest tag or return empty string if no tags exist
     env:
       MOD_RELEASE: '{{.MOD_RELEASE}}'
     cmds:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -126,29 +126,47 @@ tasks:
         TEMP_FILE=$(mktemp)
         echo "## v{{.MOD_RELEASE}}" > $TEMP_FILE
         echo "" >> $TEMP_FILE
-        echo "$RELEASE_NOTES" >> $TEMP_FILE
-        echo "" >> $TEMP_FILE
-        if [ -f CHANGELOG.md ]; then
-          tail -n +1 CHANGELOG.md >> $TEMP_FILE
-        fi
-        mv $TEMP_FILE CHANGELOG.md
+        trap 'rm -f "$TEMP_FILE"' EXIT
+        echo "## v{{.MOD_RELEASE}}" > "$TEMP_FILE"
+        echo "" >> "$TEMP_FILE"
+        echo "$RELEASE_NOTES" >> "$TEMP_FILE"
+        echo "" >> "$TEMP_FILE"
+        tail -n +1 CHANGELOG.md >> "$TEMP_FILE"
+        mv "$TEMP_FILE" CHANGELOG.md
+        trap - EXIT
         git add CHANGELOG.md
         git commit -m "chore: update CHANGELOG.md for v{{.MOD_RELEASE}}"
         git push origin release/rc-${MOD_RELEASE}
       - git tag -af ${MOD_RELEASE} -m "${MOD_RELEASE} release"
       - git push origin --tags -f
       - |
+        # Wait for the updated tag to be visible on the remote before creating the release
+        for i in {1..10}; do
+          if git ls-remote --tags origin | grep -q "refs/tags/${MOD_RELEASE}$"; then
+            echo "Tag ${MOD_RELEASE} is now available on origin."
+            break
+          fi
+          echo "Waiting for tag ${MOD_RELEASE} to propagate to origin (attempt ${i}/10)..."
+          sleep 3
+        done
         gh release create {{.MOD_RELEASE}} \
         --repo {{.REPO_OWNER}}/{{.MOD_REPO}} \
         --title "{{.MOD_RELEASE}}" \
-        --generate-notes --notes-start-tag {{.PREV_TAG}} --verify-tag
+        --generate-notes --notes-start-tag {{.PREV_TAG}}
       - |
+        RELEASE_NOTES=$(gh release view {{.MOD_RELEASE}} --repo {{.REPO_OWNER}}/{{.MOD_REPO}} --json body --jq .body)
+        PR_BODY_FILE=$(mktemp)
+        echo "Release version {{.MOD_RELEASE}}" > "$PR_BODY_FILE"
+        echo "" >> "$PR_BODY_FILE"
+        echo "$RELEASE_NOTES" >> "$PR_BODY_FILE"
         gh pr create \
         --repo {{.REPO_OWNER}}/{{.MOD_REPO}} \
         --title "Release {{.MOD_RELEASE}}" \
-        --body "Release version {{.MOD_RELEASE}}" \
+        --body-file "$PR_BODY_FILE" \
         --base main \
-        --head release/rc-${MOD_RELEASE}
+        --head release/rc-${MOD_RELEASE} || true
 
-      # - git push origin --delete release/rc-${MOD_RELEASE}
+      # Note: release/rc-${MOD_RELEASE} branches are preserved after creating the PR.
+      # To clean up after the release PR has been merged, delete the branch manually:
+      #   git push origin --delete release/rc-${MOD_RELEASE}
       - git checkout main


### PR DESCRIPTION

Overview
This PR updates the release automation process in the Taskfile and improves the markdown URL converter script.

Key Changes
Python Script (markdown-url-converter.py):

Enhanced find_markdown_files() function to ignore hidden directories (folders starting with '.')
Refactored to filter out files in hidden directories during traversal
Taskfile (release task) - Major workflow updates:

Branch naming: Changed from rel-${MOD_RELEASE} to release/rc-${MOD_RELEASE} (better Git workflow)
Revert process: Moved git revert after tag push to preserve tag in history with explicit commit message
CHANGELOG automation: Added logic to:
Fetch release notes from GitHub
Prepend new version to CHANGELOG.md
Commit and push changelog updates
Tag management: Added force retagging after all changes
Pull request creation: Now creates a release PR for review before merge to main
Cleanup: Temporarily disabled automatic branch deletion (commented out)